### PR TITLE
add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+thirdparty/
+*_jalangi_.js
+*_jalangi_.js.map
+*.pyc
+*~
+jalangi_coverage
+jalangi_sourcemap.js
+jalangi_sym_test_results
+jalangi_test_results
+jalangi_tmp/
+jalangi_trace1


### PR DESCRIPTION
This .gitignore file makes the 'git status' command much more useful.  I'm not 100% sure all the files below are safe to hide from version control, though.  Assuming they are, this should be safe to merge.
