### PR TITLE
XMLHttpRequest is not a function under JavaScriptCore / Safari

### DIFF
--- a/src/js/analysis.js
+++ b/src/js/analysis.js
@@ -506,7 +506,7 @@ if (typeof J$ === 'undefined') J$ = {};
 
             var arr = getSymbolicFunctionToInvokeAndLog(f_c, isConstructor);
             tmpIsInstrumentedCaller = isInstrumentedCaller;
-            ic = isInstrumentedCaller = f_c === undefined || HOP(f_c, SPECIAL_PROP2) || typeof f_c !== "function";
+            ic = isInstrumentedCaller = f_c === undefined || HOP(f_c, SPECIAL_PROP2) || (typeof f_c !== "function" && !(isBrowser && f_c === XMLHttpRequest));
 
             if (mode === MODE_RECORD || mode === MODE_NO_RR) {
                 invoke = true;
@@ -1146,6 +1146,8 @@ if (typeof J$ === 'undefined') J$ = {};
                             typen = T_NULL;
                         } else if (Array.isArray(val)) {
                             typen = T_ARRAY;
+                        } else if (isBrowser && val === XMLHttpRequest) {
+                            typen = T_FUNCTION;
                         } else {
                             typen = T_OBJECT;
                         }


### PR DESCRIPTION
Currently, record-replay of jQuery 2.0.2 works fine on Chrome, but not in PhantomJS.  The issue in PhantomJS is that for Safari's Webkit (JavaScriptCore), `typeof XMLHttpRequest` (and various other native functions) is `object` rather than `function`.  (This behavior remains even for the most recent version of Safari.)  This leads to replay errors for scripts like:

``` javascript
var xhrSupported = new XMLHttpRequest();
```

During replay, we get the error:

```
/Users/m.sridharan/git-repos/jalangi/src/js/analysis.js:703
                throw tmp;
                      ^
TypeError: object is not a function
    at callAsNativeConstructor (/Users/m.sridharan/git-repos/jalangi/src/js/analysis.js:441:24)
    at callAsConstructor (/Users/m.sridharan/git-repos/jalangi/src/js/analysis.js:463:27)
    at invokeFun (/Users/m.sridharan/git-repos/jalangi/src/js/analysis.js:525:31)
    at /Users/m.sridharan/git-repos/jalangi/src/js/analysis.js:618:24
    at Object.<anonymous> (/private/tmp/foo2_jalangi_.js:13:257)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```

The code change attached to this pull request "fixes" the problem, by special-casing the function test for XMLHttpRequest.  But, it's a total hack.  Unfortunately, I can't think of a more general way to detect and address this issue.  

Is there a better way to fix this problem? 
