### PR TITLE
Two new options for instrumentation; Bug fix in matching .js suffix

### DIFF
--- a/src/js/commands/instrument.js
+++ b/src/js/commands/instrument.js
@@ -83,7 +83,7 @@ function instrument(options, cb) {
     var copyDir;
 
     // analysis to run in browser (?)
-    var analysisFiles = options.analysis;
+    var analysis = options.analysis;
 
     /**
      * extra scripts to inject into the application and instrument

--- a/src/js/instrument/esnstrument.js
+++ b/src/js/instrument/esnstrument.js
@@ -84,8 +84,6 @@
     var logLastFunName = astUtil.JALANGI_VAR + "._";
 
     var instrumentCodeFunName = astUtil.JALANGI_VAR + ".instrumentCode";
-    
-    var instrEval = true; // whether to instrument code given to eval()
 
     var Syntax = {
         AssignmentExpression:'AssignmentExpression',
@@ -317,6 +315,7 @@
         fs.writeFileSync(jsonFile, JSON.stringify(outputObj));
         fs.writeFileSync(path.join(outputDir, COVERAGE_FILE_NAME), JSON.stringify({"covered":0, "branches":condCount / IID_INC_STEP * 2, "coverage":[]}), "utf8");
     }
+
 
     function printLineInfoAux(i, ast) {
         if (ast && ast.loc) {
@@ -607,8 +606,6 @@
 
     function wrapEvalArg(ast) {
         printIidToLoc(ast);
-        var code = instrEval ? instrumentCodeFunName + "(" + astUtil.JALANGI_VAR + ".getConcrete(" + RP + "1), {wrapProgram: false}," + RP +"2).code" :
-                              astUtil.JALANGI_VAR + ".getConcrete(" + RP + "1)";
         var ret = replaceInExpr(
             instrumentCodeFunName + "(" + astUtil.JALANGI_VAR + ".getConcrete(" + RP + "1), {wrapProgram: false, isEval: true}," + RP + "2).code",
             ast,


### PR DESCRIPTION
Two new options for instrumenting:
1) make on-the-fly instrumentation of eval() code optional
2) allow analyses to be implemented in multiple files

One bug fix: match ".js" only at end of file name

All tests pass.
