### PR TITLE
Chained Analysis 2 does not support instrumentCode

### DIFF
--- a/src/js/analyses2/ChainedAnalyses2.js
+++ b/src/js/analyses2/ChainedAnalyses2.js
@@ -14,7 +14,7 @@
         var funList = ["invokeFunPre", "invokeFun", "literal", "forinObject", "declare",
             "getFieldPre", "getField", "putFieldPre", "putField", "read", "write",
             "functionEnter", "functionExit", "scriptEnter", "scriptExit",
-            "binaryPre", "binary", "unaryPre", "unary", "conditional", "endExecution"];
+            "binaryPre", "binary", "unaryPre", "unary", "conditional", "instrumentCode", "endExecution"];
 
         this.addAnalysis = function (analysis) {
             var self = this, tmp, length = funList.length;


### PR DESCRIPTION
add the string to support instrumentCode interface in chained analysis 2.
all npm tests passed
